### PR TITLE
[8.0][ADD|FIX] Número autorización de facturas y facturación desde compras

### DIFF
--- a/l10n_ec_authorisation/authorisation.py
+++ b/l10n_ec_authorisation/authorisation.py
@@ -234,6 +234,10 @@ class AccountInvoice(models.Model):
         copy=False
     )
 
+    @api.onchange('auth_inv_id')
+    def onchange_auth_inv_id(self):
+        self.reference = self.auth_inv_id and self.auth_inv_id.name or ""
+
     @api.onchange(
         'supplier_invoice_number',
         'auth_inv_id'

--- a/l10n_ec_authorisation_purchase/README.rst
+++ b/l10n_ec_authorisation_purchase/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================================================
+Módulo para Gestión de Establecimientos desde compras
+=====================================================
+
+Este módulo permite facturar compras junto el número de autorización.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Do this ...
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to ...
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/{repo_id}/{branch}
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/odoo-ecuador/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Contributors
+------------
+
+* Jose Zambudio  <jose.zambudio@diagram.es>

--- a/l10n_ec_authorisation_purchase/__init__.py
+++ b/l10n_ec_authorisation_purchase/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Diagram Software S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+from . import models

--- a/l10n_ec_authorisation_purchase/__openerp__.py
+++ b/l10n_ec_authorisation_purchase/__openerp__.py
@@ -12,7 +12,6 @@
     ],
     'depends': [
         'purchase',
-        'l10n_ec_authorisation',
         'l10n_ec_withdrawing',
     ],
     'installable': True,

--- a/l10n_ec_authorisation_purchase/__openerp__.py
+++ b/l10n_ec_authorisation_purchase/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2016 Diagram Software S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    'name': 'Purchase - SRI Authorisation Documents',
+    'version': '8.0.1.0.0',
+    'author': "Diagram Software S.L., "
+              'Jose Zambudio',
+    'category': 'Localization',
+    'data': [
+    ],
+    'depends': [
+        'purchase',
+        'l10n_ec_authorisation',
+        'l10n_ec_withdrawing',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/l10n_ec_authorisation_purchase/models/__init__.py
+++ b/l10n_ec_authorisation_purchase/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Diagram Software S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+from . import purchase

--- a/l10n_ec_authorisation_purchase/models/purchase.py
+++ b/l10n_ec_authorisation_purchase/models/purchase.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# © 2016 Diagram Software S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+from openerp import api, models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    @api.model
+    def _prepare_invoice(self, order, lines):
+        """
+            Borramos el campo reference por defecto para que no choque con el
+            constraint del módulo l10n_ec_withdrawing 'check_reference'
+        """
+        res = super(PurchaseOrder, self)._prepare_invoice(order, lines)
+        if 'reference' in res:
+            res.pop("reference")
+        authorisation = self.env['account.authorisation'].search(
+            [('partner_id', '=', res.get("partner_id")),
+             ('in_type', '=', 'externo')],
+            limit=1
+        )
+        if authorisation:
+            res['auth_inv_id'] = authorisation.id
+            res['reference'] = authorisation.name
+        return res

--- a/l10n_ec_withdrawing/withdrawing_view.xml
+++ b/l10n_ec_withdrawing/withdrawing_view.xml
@@ -493,7 +493,6 @@
             <field name="inherit_id" ref="base.view_company_form"/>
             <field name="arch" type="xml">
 	        <field name="partner_id" position="after">
-	            <field name="ruc_contador"/>
 	            <field name="cedula_rl"/>
 	        </field>
             </field>


### PR DESCRIPTION
Para el módulo **l10n_ec_authorisation** se ha añadido un onchange para
rellenar el campo Número de autorización con respecto al registro
seleccionado en el campo: _auth_inv_id_.

Se ha creado un nuevo módulo **l10n_ec_authorisation_purchase** que devuelve
los datos de la factura a crear desde el pedido de compra con los valores
de los campos _auth_inv_id_ y _reference_. De esta forma no choca con el
constraint _check_reference_ del módulo: **l10n_ec_withdrawing**

Además se ha quitado el campo _ruc_contador_ de la vista _view_company_form_ que
hereda el módulo **l10n_ec_withdrawing** ya que este campo lo añade el módulo
**l10n_ec_partner**.
