### PR TITLE
Error Ortografico l10n_ec_chart 8.0

### DIFF
--- a/l10n_ec_authorisation/data/account.ats.doc.csv
+++ b/l10n_ec_authorisation/data/account.ats.doc.csv
@@ -1,12 +1,12 @@
 id,code,name
-01,1,Factura 
-02,2,Nota o boleta de venta 
-03,3,Liquidación de compra de Bienes o Prestación de servicios 
-04,4,Nota de crédito
-05,5,Nota de débito
-06,7,Comprobante de Retención
-07,8,Boletos o entradas a espectáculos públicos
-08,9,Tiquetes o vales emitidos por máquinas registradoras
+01,01,Factura 
+02,02,Nota o boleta de venta 
+03,03,Liquidación de compra de Bienes o Prestación de servicios 
+04,04,Nota de crédito
+05,05,Nota de débito
+06,07,Comprobante de Retención
+07,08,Boletos o entradas a espectáculos públicos
+08,09,Tiquetes o vales emitidos por máquinas registradoras
 09,11,Pasajes expedidos por empresas de aviación
 10,12,Documentos emitidos por instituciones financieras
 11,15,Comprobante de venta emitido en el Exterior

--- a/l10n_ec_chart/__openerp__.py
+++ b/l10n_ec_chart/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Ecuador - Accounting Chart',
     'version': '1.1',
-    'category': 'Localisation/Account Charts',
+    'category': 'Localization/Account Charts',
     'description': """
     This is the base module to manage
     the accounting chart for Ecuador in OpenERP.


### PR DESCRIPTION
'category': 'Localisation/Account Charts', por
'category': 'Localization/Account Charts',

Este error no permite que el modulo 'Ecuador - Accounting Chart' se encasille en la categoria "plan de cuentas", por lo que al instalar contabilidad financiera no aparece en la lista