### PR TITLE
[8.0][REF] Abandonar el uso de "ced_ruc" en pro de "vat"

### DIFF
--- a/l10n_ec_authorisation/tests/test_authorisation.py
+++ b/l10n_ec_authorisation/tests/test_authorisation.py
@@ -32,7 +32,7 @@ class TestAuthorisation(TransactionCase):  # pylint: disable=W0232
             cursor,
             user_id,
             {
-                'ced_ruc': '0103893962',
+                'vat': '0103893962',
                 'name': 'CRISTIAN GONZALO SALAMEA MALDONADO',
                 'type_ced_ruc': 'cedula',
                 'tipo_persona': '6'

--- a/l10n_ec_einvoice/edocument.py
+++ b/l10n_ec_einvoice/edocument.py
@@ -67,7 +67,7 @@ class Edocument(models.AbstractModel):
             'tipoEmision': emission_code,
             'razonSocial': company.name,
             'nombreComercial': company.name,
-            'ruc': company.partner_id.ced_ruc,
+            'ruc': company.partner_id.vat,
             'claveAcceso':  access_key,
             'codDoc': utils.tipoDocumento[auth.type_id.code],
             'estab': auth.serie_entidad,
@@ -96,7 +96,7 @@ class Edocument(models.AbstractModel):
         ld.reverse()
         fecha = ''.join(ld)
         tcomp = utils.tipoDocumento[auth.type_id.code]
-        ruc = self.company_id.partner_id.ced_ruc
+        ruc = self.company_id.partner_id.vat
         serie = '{0}{1}'.format(auth.serie_entidad, auth.serie_emision)
         codigo_numero = self.get_code()
         tipo_emision = self.company_id.emission_code

--- a/l10n_ec_einvoice/einvoice.py
+++ b/l10n_ec_einvoice/einvoice.py
@@ -34,7 +34,7 @@ class AccountInvoice(models.Model):
             'obligadoContabilidad': 'SI',
             'tipoIdentificacionComprador': utils.tipoIdentificacion[partner.type_ced_ruc],  # noqa
             'razonSocialComprador': partner.name,
-            'identificacionComprador': partner.ced_ruc,
+            'identificacionComprador': partner.vat,
             'totalSinImpuestos': '%.2f' % (invoice.amount_untaxed),
             'totalDescuento': '0.00',
             'propina': '0.00',

--- a/l10n_ec_einvoice/eretention.py
+++ b/l10n_ec_einvoice/eretention.py
@@ -36,7 +36,7 @@ class AccountWithdrawing(models.Model):
             'obligadoContabilidad': 'SI',
             'tipoIdentificacionSujetoRetenido': utils.tipoIdentificacion[partner.type_ced_ruc],  # noqa
             'razonSocialSujetoRetenido': partner.name,
-            'identificacionSujetoRetenido': partner.ced_ruc,
+            'identificacionSujetoRetenido': partner.vat,
             'periodoFiscal': withdrawing.period_id.name,
             }
         if company.company_registry:

--- a/l10n_ec_einvoice/views/report_einvoice.mako
+++ b/l10n_ec_einvoice/views/report_einvoice.mako
@@ -150,7 +150,7 @@
 	  <div class="invoiceinfo">
 	    <div class="info">
 	      <b>RUC:</b>
-	      ${o.company_id.partner_id.ced_ruc}
+	      ${o.company_id.partner_id.vat}
 	    </div>
 	    <div class="info" style="text-align: center;">
 	      <div style="text-align: center;">
@@ -203,7 +203,7 @@
 		<b>RUC/CI:</b>
 	      </td>
 	      <td style="width: 10%; font-size:14px;">
-		${ o.partner_id.ced_ruc }
+		${ o.partner_id.vat }
 	      </td>
 	    </tr>
 	    <tr>

--- a/l10n_ec_partner/__openerp__.py
+++ b/l10n_ec_partner/__openerp__.py
@@ -2,16 +2,19 @@
 
 {
     'name': 'OpenERP Partner for Ecuador',
-    'version': '0.1.0',
+    'version': '8.0.1.0.0',
     'author': 'Cristian Salamea',
     'category': 'Localization',
     'complexity': 'normal',
     'website': 'http://www.ayni.com.ec',
+    'external_dependencies': {
+        'python': ['stdnum']
+    },
+    'depends': [
+        'base', 'base_vat'
+    ],
     'data': [
         'view/partner_view.xml',
-    ],
-    'depends': [
-        'base'
     ],
     'installable': True,
 }

--- a/l10n_ec_partner/migrations/8.0.1.0/pre-migration.py
+++ b/l10n_ec_partner/migrations/8.0.1.0/pre-migration.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+__name__ = (
+    u'Elimina la restricción de indentificador único a nivel de SGDB y'
+    ' mueve el contenido de la columna "ced_ruc" a "vat".')
+
+
+def test_column_exists(cr, table, column):
+    cr.execute("""
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name=%s AND column_name=%s""", (table, column))
+    return cr.fetchone()
+
+
+def fix_ced_ruc(cr):
+    if test_column_exists(cr, 'res_partner', 'ced_ruc'):
+        _logger.info('Moviendo contenido de "ced_ruc" a "vat"...')
+        cr.execute("""UPDATE res_partner SET vat = ced_ruc
+                      WHERE COALESCE(ced_ruc, '') != ''""")
+        _logger.info('Eliminando la columna "ced_ruc"...')
+        cr.execute("ALTER TABLE res_partner DROP COLUMN ced_ruc")
+
+
+def fix_vat_unique(cr):
+    _logger.info('Eliminando resticción de unicidad del identificador...')
+    cr.execute(
+        'ALTER TABLE res_partner DROP CONSTRAINT res_partner_partner_unique')
+
+
+def migrate(cr, version):
+    fix_ced_ruc(cr)
+    fix_vat_unique(cr)

--- a/l10n_ec_partner/migrations/8.0.1.0/pre-migration.py
+++ b/l10n_ec_partner/migrations/8.0.1.0/pre-migration.py
@@ -27,8 +27,8 @@ def fix_ced_ruc(cr):
 
 def fix_vat_unique(cr):
     _logger.info('Eliminando resticción de unicidad del identificador...')
-    cr.execute(
-        'ALTER TABLE res_partner DROP CONSTRAINT res_partner_partner_unique')
+    cr.execute("""ALTER TABLE res_partner
+                  DROP CONSTRAINT IF EXISTS res_partner_partner_unique""")
 
 
 def migrate(cr, version):

--- a/l10n_ec_partner/partner.py
+++ b/l10n_ec_partner/partner.py
@@ -1,8 +1,28 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, fields
+import logging
+import urllib
+import urllib2
 
-from stdnum import ec
+from openerp import api, models, fields
+
+_logger = logging.getLogger(__name__)
+
+STDNUM__ge__1_0 = False
+try:
+    import stdnum
+    try:
+        from stdnum import ec
+        STDNUM__ge__1_0 = True
+    except ImportError:
+        _logger.warning(
+            'l10n_ec_partner: required library version stdnum >= 1.0 found: %s',
+            stdnum.__version__)
+except ImportError:
+    _logger.warning(
+        'l10n_ec_partner: required library not found: stdnum >= 1.0')
+
+SRI_URL = 'https://declaraciones.sri.gob.ec/facturacion-internet/consultas/publico/ruc-datos2.jspa'  # noqa
 
 
 class ResPartner(models.Model):
@@ -15,57 +35,82 @@ class ResPartner(models.Model):
         if not context:
             context = {}
         if name:
-            ids = self.search(cr, uid, [('ced_ruc', operator, name)] + args, limit=limit, context=context)  # noqa
+            ids = self.search(cr, uid, [('vat', operator, name)] + args, limit=limit, context=context)  # noqa
             if not ids:
                 ids = self.search(cr, uid, [('name', operator, name)] + args, limit=limit, context=context)  # noqa
         else:
             ids = self.search(cr, uid, args, limit=limit, context=context)
         return self.name_get(cr, uid, ids, context)
 
-    def _check_ced_ruc(self, cr, uid, ids):
-        for partner in self.browse(cr, uid, ids):
-            if partner.type_ced_ruc == 'cedula':
-                return ec.ci.is_valid(partner.ced_ruc)
-            elif partner.type_ced_ruc == 'ruc':
-                return ec.ruc.is_valid(partner.ced_ruc)
-            else:
-                return True
-
     ced_ruc = fields.Char(
-        'Cedula/ RUC',
-        size=13,
-        required=True,
-        help='Identificación o Registro Unico de Contribuyentes')
-    type_ced_ruc = fields.Selection(
-        [
-            ('cedula', 'CEDULA'),
-            ('ruc', 'RUC'),
-            ('pasaporte', 'PASAPORTE')
-            ],
-        'Tipo ID',
-        required=True,
-        default='pasaporte'
-    )
-    tipo_persona = fields.Selection(
-        [
-            ('6', 'Persona Natural'),
-            ('9', 'Persona Juridica')
-        ],
-        string='Persona',
-        required=True,
-        default='9'
-    )
+        'Cedula/RUC', compute='_compute_ced_ruc', inverse='_inverse_ced_ruc',
+        help='Identificación o Registro Unico de Contribuyentes.',
+        deprecated=True)
+    type_ced_ruc = fields.Selection([
+        ('cedula', 'CEDULA'),
+        ('ruc', 'RUC'),
+        ('pasaporte', 'PASAPORTE')
+    ], string='Tipo ID')
+    tipo_persona = fields.Selection([
+        ('6', 'Persona Natural'),
+        ('9', 'Persona Juridica')
+    ], string='Persona', required=True, default='9')
     is_company = fields.Boolean(default=True)
 
-    _constraints = [
-        (_check_ced_ruc, 'Error en su Cedula/RUC/Pasaporte', ['ced_ruc'])
-        ]
+    @api.multi
+    def check_vat(self):
+        for rec in self.filtered(lambda r: r.vat):
+            if not super(ResPartner, rec.with_context(
+                    type_ced_ruc=rec.type_ced_ruc)).check_vat():
+                return False
+        return True
 
-    _sql_constraints = [
-        ('partner_unique',
-         'unique(ced_ruc,type_ced_ruc,tipo_persona,company_id)',
-         u'El identificador es único.'),
-        ]
+    @api.multi
+    def _construct_constraint_msg(self):
+        return super(ResPartner, self)._construct_constraint_msg()
+
+    _constraints = [(check_vat, _construct_constraint_msg, ['vat'])]
+
+    @api.multi
+    @api.depends('vat')
+    def _compute_ced_ruc(self):
+        for rec in self:
+            rec.ced_ruc = rec.vat
+
+    @api.multi
+    def _inverse_ced_ruc(self):
+        for rec in self:
+            rec.vat = rec.ced_ruc
+
+    @api.model
+    def simple_vat_check(self, country_code, vat_number):
+        ctx = self.env.context
+
+        if country_code.upper() == 'EC' and ctx.get('type_ced_ruc'):
+            vat_number = '%%(%s)s%s' % (ctx['type_ced_ruc'], vat_number) % {
+                'cedula': 'C', 'ruc': 'R', 'pasaporte': 'P'}
+
+        return super(ResPartner, self).simple_vat_check(country_code, vat_number)  # noqa
+
+    def check_vat_ec(self, vat):
+        """ Validación del Nº de Cédula/Ruc para Ecuador. """
+        if len(vat) < 2:
+            return False
+
+        type_ced_ruc, vat = vat[0].upper(), vat[1:]
+
+        if not STDNUM__ge__1_0:
+            # No podemos validar, avisamos en los logs
+            _logger.warning('Unable to validate VAT %s', vat)
+            return True
+        elif type_ced_ruc == 'C':  # Cédula de Identidad
+            return ec.ci.is_valid(vat)
+        elif type_ced_ruc == 'R':  # Registro Único de Contribuyentes
+            return ec.ruc.is_valid(vat)
+        elif type_ced_ruc == 'P':  # Pasaporte
+            return True  # TODO
+
+        return False
 
     def validate_from_sri(self):
         """
@@ -73,6 +118,20 @@ class ResPartner(models.Model):
         """
         SRI_LINK = "https://declaraciones.sri.gob.ec/facturacion-internet/consultas/publico/ruc-datos1.jspa"  # noqa
         texto = '0103893954'  # noqa
+
+    @api.multi
+    def sri_vat_check(self, country_code, vat_number):
+        """ TODO: Valida mediante el Servicio de Rentas Internas. """
+        req = urllib2.Request(SRI_URL, urllib.urlencode({
+            'accion': 'siguiente',
+            'ruc': vat_number,
+            'lineasPagina': ''
+        }))
+        try:
+            urllib2.urlopen(req)  # 200
+            return True
+        except urllib2.HTTPError:  # 500
+            return False
 
 
 class ResCompany(models.Model):

--- a/l10n_ec_partner/partner.py
+++ b/l10n_ec_partner/partner.py
@@ -57,6 +57,10 @@ class ResPartner(models.Model):
     ], string='Persona', required=True, default='9')
     is_company = fields.Boolean(default=True)
 
+    @api.model
+    def _commercial_fields(self):
+        return super(ResPartner, self)._commercial_fields() + ['type_ced_ruc']
+
     @api.multi
     def check_vat(self):
         for rec in self.filtered(lambda r: r.vat):

--- a/l10n_ec_partner/tests/test_partner.py
+++ b/l10n_ec_partner/tests/test_partner.py
@@ -14,7 +14,7 @@ class PartnerTest(TransactionCase):
             cursor,
             user_id,
             {
-                'ced_ruc': '0103893962',
+                'vat': '0103893962',
                 'name': 'CRISTIAN GONZALO SALAMEA MALDONADO',
                 'type_ced_ruc': 'cedula',
                 'tipo_persona': '6'

--- a/l10n_ec_partner/view/partner_view.xml
+++ b/l10n_ec_partner/view/partner_view.xml
@@ -32,7 +32,7 @@
         <record id="view_res_partner_cedruc_form" model="ir.ui.view">
             <field name="name">res.partner.cedruc.form</field>
             <field name="model">res.partner</field>
-            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="inherit_id" ref="base_vat.view_partner_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//label[@for='name']" position="attributes">
                     <attribute name="string">Razón Social</attribute>

--- a/l10n_ec_partner/view/partner_view.xml
+++ b/l10n_ec_partner/view/partner_view.xml
@@ -12,7 +12,7 @@
             <field name="inherit_id" ref="base.view_res_partner_filter"/>
             <field name="arch" type="xml">
                 <field name="name" position="before">
-                    <field name="ced_ruc"/>
+                    <field name="vat"/>
                     <field name="ref"/>
                 </field>
             </field>
@@ -24,7 +24,7 @@
             <field name="inherit_id" ref="base.view_partner_tree"/>
             <field name="arch" type="xml">
                 <xpath expr="/tree/field[@name='display_name']" position="before">
-                    <field name="ced_ruc"/>
+                    <field name="vat"/>
                 </xpath>
             </field>
         </record>
@@ -37,14 +37,16 @@
                 <xpath expr="//label[@for='name']" position="attributes">
                     <attribute name="string">Razón Social</attribute>
                 </xpath>
+
                 <xpath expr="//field[@name='parent_id']" position="after">
-                    <div>
-	                    <field name="type_ced_ruc" placeholder="Tipo de Identificador" class="oe_inline"/>
-	                    <field name="ced_ruc" placeholder="Cédula / RUC" class="oe_inline"/>
-                    </div>
                     <field name="tipo_persona" placeholder="Tipo de Persona"/>
                     <newline/>
                 </xpath>
+
+                <xpath expr="//field[@name='vat_subjected']" position="after">
+                    <field name="type_ced_ruc" placeholder="Tipo de Identificador" class="oe_inline"/>
+                </xpath>
+
             </field>
         </record>
 

--- a/l10n_ec_pos/static/src/js/pos.js
+++ b/l10n_ec_pos/static/src/js/pos.js
@@ -5,8 +5,8 @@ function l10n_ec_pos(instance, module) {
 
     _partner_search_string: function(partner){
       var str =  partner.name;
-      if(partner.ced_ruc){
-        str += '|' + partner.ced_ruc;
+      if(partner.vat){
+        str += '|' + partner.vat;
       }
       if(partner.ean13){
         str += '|' + partner.ean13;
@@ -41,7 +41,7 @@ function l10n_ec_pos(instance, module) {
         },{ 
             model:  'res.company',
             fields: [ 'currency_id', 'email', 'website', 'company_registry', 'vat', 'name', 'phone', 'partner_id' , 'country_id'],
-            ids:    function(self){ return [self.user.company_id[0]] },
+            ids:    function(self){ return [self.user.company_id[0]]; },
             loaded: function(self,companies){ self.company = companies[0]; },
         },{
             model:  'decimal.precision',
@@ -73,7 +73,7 @@ function l10n_ec_pos(instance, module) {
             loaded: function(self,users){ self.users = users; },
         },{
             model:  'res.partner',
-            fields: ['type_ced_ruc','ced_ruc','name','street','city','state_id','country_id','vat','phone','zip','mobile','email','ean13','write_date'],
+          fields: ['name','street','city','state_id','country_id','vat','phone','zip','mobile','email','ean13','write_date'],
             domain: [['customer','=',true]],
             loaded: function(self,partners){
                 self.partners = partners;
@@ -256,7 +256,7 @@ function l10n_ec_pos(instance, module) {
                     var height = Math.floor(img.height * ratio);
                     var c = document.createElement('canvas');
                         c.width  = width;
-                        c.height = height
+                        c.height = height;
                     var ctx = c.getContext('2d');
                         ctx.drawImage(self.company_logo,0,0, width, height);
 
@@ -286,5 +286,5 @@ function l10n_ec_pos(instance, module) {
 
         l10n_ec_pos(instance, module);
 
-    }
-})()
+    };
+})();

--- a/l10n_ec_pos/static/src/xml/pos.xml
+++ b/l10n_ec_pos/static/src/xml/pos.xml
@@ -30,7 +30,7 @@
             </div>
             <div class='client-detail'>
               <span class='label'>RUC</span>
-              <input class='detail client-address-street' name='ced_ruc' t-att-value='partner.ced_ruc' placeholder='Cedula / RUC'></input>
+              <input class='detail client-address-street' name='vat' t-att-value='partner.vat' placeholder='Cedula / RUC'></input>
             </div>
             <div class='client-detail'>
               <span class='label'>Dirección</span>
@@ -55,7 +55,7 @@
   <t t-extend="ClientLine">
     <t t-jquery=".client-line" t-operation="replace">
       <tr class='client-line' t-att-data-id='partner.id'>
-        <td><t t-esc='partner.ced_ruc' /></td>
+        <td><t t-esc='partner.vat' /></td>
         <td><t t-esc='partner.name' /></td>
         <td><t t-esc='partner.address' /></td>
         <td><t t-esc='partner.phone or partner.mobile or ""' /></td>
@@ -106,7 +106,7 @@
             </div>
             <div class='client-detail'>
               <span class='label'>RUC</span>
-              <span class='detail client-address'><t t-esc='partner.ced_ruc' /></span>
+              <span class='detail client-address'><t t-esc='partner.vat' /></span>
             </div>
             <div class='client-detail'>
               <span class='label'>Dirección</span>
@@ -144,7 +144,7 @@
         <div class="pos-center-align"><t t-esc="order.get('name')"/></div>
         <t t-if="order.get_client()">
           <span><t t-esc="order.get_client_name()"/></span><br />
-          <span><t t-esc="order.get_client().ced_ruc"/></span><br />
+          <span><t t-esc="order.get_client().vat"/></span><br />
           <span><t t-esc="order.get_client().street"/></span><br />
         </t>
         <t t-esc="new Date().toString(Date.CultureInfo.formatPatterns.shortDate)"/><br />

--- a/l10n_ec_withdrawing/report/account_invoice.mako
+++ b/l10n_ec_withdrawing/report/account_invoice.mako
@@ -41,7 +41,7 @@
     </tr>
     <tr>
       <td width="8%"></td>
-	  <td colspan="3">${o.partner_id.ced_ruc or '##########'}</td>	
+	  <td colspan="3">${o.partner_id.vat or '##########'}</td>	
     </tr>
   </table>
   <br><br>

--- a/l10n_ec_withdrawing/report/account_liq.mako
+++ b/l10n_ec_withdrawing/report/account_liq.mako
@@ -33,7 +33,7 @@
         <td width="100" style="font-size:12;">${o.date_invoice or ''}</td>	
     </tr>
     <tr>
-	<td style="font-size:12;">${o.partner_id.ced_ruc or '##########'}</td>	
+	<td style="font-size:12;">${o.partner_id.vat or '##########'}</td>	
         <td style="font-size:12;">${o. address_invoice_id and o.address_invoice_id.city or ''}</td>	
 
     </tr>

--- a/l10n_ec_withdrawing/report/account_retention.mako
+++ b/l10n_ec_withdrawing/report/account_retention.mako
@@ -46,7 +46,7 @@
       <td></td><td></td><td></td>
     </tr>
     <tr>
-	<td style="font-size:12;">${o.partner_id.ced_ruc or '##########'}</td>	
+	<td style="font-size:12;">${o.partner_id.vat or '##########'}</td>	
 	<td></td>
 	<td style="font-size:12;text-align:center;">${(o.type == 'in_invoice') and 'Factura' or ''} ${(o.type == 'liq_purchase') and 'Liq. de Compra' or ''} </td>	
     </tr>	

--- a/l10n_ec_withdrawing/wizard/wizard_ats.py
+++ b/l10n_ec_withdrawing/wizard/wizard_ats.py
@@ -120,7 +120,7 @@ class wizard_ats(orm.TransientModel):
         inv_obj = self.pool.get('account.invoice')
         wiz = self.browse(cr, uid, ids)[0]
         period_id = wiz.period_id.id
-        ruc = wiz.company_id.partner_id.ced_ruc
+        ruc = wiz.company_id.partner_id.vat
         ats = etree.Element('iva')
         etree.SubElement(ats, 'TipoIDInformante').text = 'R'
         etree.SubElement(ats, 'IdInformante').text = str(ruc)
@@ -142,10 +142,10 @@ class wizard_ats(orm.TransientModel):
         for inv in inv_obj.browse(cr, uid, inv_ids):
             detallecompras = etree.Element('detalleCompras')
             etree.SubElement(detallecompras, 'codSustento').text = inv.sustento_id.code  # noqa
-            if not inv.partner_id.ced_ruc:
+            if not inv.partner_id.vat:
                 raise osv.except_osv('Datos incompletos', 'No ha ingresado toda los datos de %s' % inv.partner_id.name)  # noqa
             etree.SubElement(detallecompras, 'tpIdProv').text = tpIdProv[inv.partner_id.type_ced_ruc]  # noqa
-            etree.SubElement(detallecompras, 'idProv').text = inv.partner_id.ced_ruc  # noqa
+            etree.SubElement(detallecompras, 'idProv').text = inv.partner_id.vat  # noqa
             if inv.auth_inv_id:
                 tcomp = inv.auth_inv_id.type_id.code
             else:
@@ -229,7 +229,7 @@ class wizard_ats(orm.TransientModel):
                 partner_data = {
                     keyp: {
                         'tpIdCliente': inv.partner_id.type_ced_ruc,
-                        'idCliente': inv.partner_id.ced_ruc,
+                        'idCliente': inv.partner_id.vat,
                         'numeroComprobantes': 0,
                         'basenoGraIva': 0,
                         'baseImponible': 0,


### PR DESCRIPTION
Modificado el campo `ced_ruc` para que se pueda volver a utilizar el campo `vat` de `res.partner`. Esto nos ofrece una serie de ventajas:
- Gestionar el valor con la funcionalidad estándar.
- Permite hacer uso del módulo `base_vat` de **Odoo** para la validación.
- Permite el uso de módulos externos (p.ej., `base_vat_unique`).

Se ha realizado de la forma menos agresiva posible para asegurar que:
- `ced_ruc` sigue siendo accesible y muestra el valor almacenado en `vat`.
- `ced_ruc` sigue siendo editable y almacena el valor en `vat`.
- Se propaga correctamente el valor `ced_ruc` a `vat` sin que se pierda en la actualización.
- Se elimina la columna `ced_ruc` de la tabla `res_partner` para evitar confusión.

El PR incluye otros cambios como:
- Asegurar que la versión de `stdnum` sea igual o superior a la `1.0`, las versiones anteriores no son capaces de validar la CI/RUC ([changelog][1]).
- Propaga el valor de `type_ced_ruc` en la creación de contactos.

[1]: https://launchpad.net/ubuntu/+source/python-stdnum/1.0-1