### PR TITLE
[REM] Quitando onchange duplicado con la api nueva

### DIFF
--- a/l10n_ec_withdrawing/withdrawing_view.xml
+++ b/l10n_ec_withdrawing/withdrawing_view.xml
@@ -163,7 +163,7 @@
                         <group>
                             <group>
                                 <field name="partner_id" select="1" attrs="{'required':[('to_cancel','=',False)], 'invisible':[('to_cancel','=',True)]}"/>
-                                <field name="invoice_id" on_change="onchange_invoice(invoice_id)"
+                                <field name="invoice_id"
                                        attrs="{'required':[('to_cancel','=',False)], 'invisible':[('to_cancel','=',True)]}"/>
                                 <field name="date" select="1"/>
                                 <field name="in_type" required="1"/>


### PR DESCRIPTION
Estaba el on_change en la vista y definido en el modelo con @api.onchange